### PR TITLE
Option -stable shouldn't pull if release file exists

### DIFF
--- a/strato-run.sh
+++ b/strato-run.sh
@@ -86,7 +86,10 @@ then
     if [ "$mode" != "1" ] ; then curl http://api.mixpanel.com/track/?data=ewogICAgImV2ZW50IjogInN0cmF0b19nc19pbml0IiwKICAgICJwcm9wZXJ0aWVzIjogewogICAgICAgICJ0b2tlbiI6ICJkYWYxNzFlOTAzMGFiYjNlMzAyZGY5ZDc4YjZiMWFhMCIKICAgIH0KfQ==&ip=1 ;fi
     if [ "$stable" = true ]
     then
-      curl -s -L https://github.com/blockapps/strato-getting-started/releases/latest | egrep -o '/blockapps/strato-getting-started/releases/download/build-[0-9]*/docker-compose.release.yml' | wget --base=http://github.com/ -i - -O docker-compose.release.yml
+      if [ ! -f docker-compose.release.yml ]; then
+        echo "Getting stable release docker-compose.release.yml from latest release tag: https://github.com/blockapps/strato-getting-started/releases/latest"
+        curl -s -L https://github.com/blockapps/strato-getting-started/releases/latest | egrep -o '/blockapps/strato-getting-started/releases/download/build-[0-9]*/docker-compose.release.yml' | wget --base=http://github.com/ -i - -O docker-compose.release.yml
+      fi
       docker-compose -f docker-compose.release.yml -p strato up -d
     else
       curl -L https://github.com/blockapps/strato-getting-started/releases/download/build-latest/docker-compose.latest.yml -O


### PR DESCRIPTION
Default --stable option to run with existing docker-compose.release.yml 
If the release file isn't found, pull from latest-release and run with updated images.
https://blockapps.atlassian.net/browse/STRATO-179