### PR TITLE
Use docker-compose down instead of kill to avoid nginx ignoring the signals

### DIFF
--- a/strato.sh
+++ b/strato.sh
@@ -16,8 +16,7 @@ NC='\033[0m'
 
 function wipe {
     echo "Removing STRATO containers and wiping out volumes"
-    docker-compose -f docker-compose.yml -p strato stop -t 0
-    docker-compose -f docker-compose.yml -p strato down -v
+    docker-compose -f docker-compose.yml -p strato down -v -t 0
 }
 
 function stop {

--- a/strato.sh
+++ b/strato.sh
@@ -16,7 +16,7 @@ NC='\033[0m'
 
 function wipe {
     echo "Removing STRATO containers and wiping out volumes"
-    docker-compose -f docker-compose.yml -p strato kill
+    docker-compose -f docker-compose.yml -p strato stop -t 0
     docker-compose -f docker-compose.yml -p strato down -v
 }
 


### PR DESCRIPTION
the signal. Since we are wiping the volumes anyways, don't leave a graceful timeout