### PR TITLE
Don't set $genesisBlock if $genesis is set.

### DIFF
--- a/strato.sh
+++ b/strato.sh
@@ -143,7 +143,7 @@ else
     echo "bootnode: $bootnode"
     echo "useSyncMode: $useSyncMode"
   fi
-  if [ -e "genesis-block.json" ]
+  if [ -e "genesis-block.json" && -z $genesis ]
   then
     export genesisBlock=$(< genesis-block.json)
   fi


### PR DESCRIPTION
$genesisBlock overrides $genesis, so the existence of genesis-block.json
prevents selecting a different pre-baked Genesis.json file