### PR TITLE
Don't allow the cirrus container to escape

### DIFF
--- a/strato.sh
+++ b/strato.sh
@@ -235,5 +235,5 @@ then
 else
   echo -e "${BYellow}Using the existing docker-compose.yml (to download the most recent stable version - remove the file and restart the script)${NC}"
 fi
-docker-compose -f docker-compose.yml -p strato up -d
+docker-compose -f docker-compose.yml -p strato up -d --remove-orphans
 exit 0;

--- a/strato.sh
+++ b/strato.sh
@@ -49,12 +49,12 @@ EXT_STORAGE_S3_SECRET_ACCESS_KEY  - the secret access key for AWS S3 bucket prov
 
 function wipe {
   echo "Removing STRATO containers and wiping out volumes"
-  docker-compose -f docker-compose.yml -p strato down -v -t 0
+  docker-compose -f docker-compose.yml -p strato down -v -t 0 --remove-orphans
 }
 
 function stop {
   echo "Gently stopping and removing STRATO containers"
-  docker-compose -f docker-compose.yml -p strato down
+  docker-compose -f docker-compose.yml -p strato down --remove-orphans
 }
 
 function getCompose {


### PR DESCRIPTION
The help text is I think overly broad "Remove containers for services not defined in the Compose file", because it appears able to detect that a container is formerl y from the service.