### PR TITLE
OPS-294

### DIFF
--- a/strato
+++ b/strato
@@ -52,7 +52,7 @@ ${Yellow}Optional flags for STRATO:${NC}
 --single              - run the single PBFT-blockstanbul node
 --lazy                - run the the lazy mining node (single);
 --blockstanbul|--pbft - run the PBFT-blockstanbul node - equal to env var blockstanbul=true; requires additional env vars (blockstanbulPrivateKey, validators)
---upgrade-strato      - run strato and keep previous volume
+--restart-strato      - restart strato with the same docker compose and keep previous volume
 
 ${Yellow}Environment variables:${NC}
 PASSWORD        - node in-memory password for STRATO v4.5+ with OAuth enabled. To be requested interactively if skipped
@@ -131,7 +131,7 @@ function keygen {
 
 function mountStratoVolume {
   echo -e "${BYellow}STRATO container already exists. Restarting"
-  docker-compose -p strato up -d --no-deps strato
+  docker-compose -p strato stop && docker-compose -p strato start
   echo -e "${Green}STRATO container has restarted."
   exit 0
 }
@@ -271,7 +271,7 @@ while [ ${#} -gt 0 ]; do
   --lazy)
     node_type=lazy
     ;;
-  --upgrade-strato)
+  --restart-strato)
     mountStratoVolume
     ;;
   --compose)
@@ -427,14 +427,6 @@ then
 
 elif [ ${node_type} = single ]
 then
-  if [ "$(docker ps -a | grep strato_strato_1 )" ]
-  then
-    docker exec -it strato_strato_1 [ -f var/lib/strato/logs/strato-setup ]
-      if [ $? = 0 ]
-      then
-        mountStratoVolume
-      fi
-  fi
   echo "" && echo -e "${BYellow}Running single node with PBFT-blockstanbul${NC}"
   keys_json=$(keygen 1)
   export blockstanbul=true


### PR DESCRIPTION
Since we have developed upgrade steps, I changed the flag `upgrade-strato` to `restart-strato` in this PR, which we can use to restart strato without losing volumes. Its practicality is yet to explore.... I think it can be used as a quick try to fix weird not-syncing or stalling issues.

Tested:
 ```[2019-11-12 20:15:19.547277489 UTC]  INFO | ThreadId 11    | blockstanbul/InShortLog             | ROUNDCHANGE View (round = 8, sequence = 0) 690d3131bb8fce05f6fb79dffaaa4be687c766a0
[2019-11-12 20:15:19.547546535 UTC]  INFO | ThreadId 11    | showctx/view                        | View (round = 8, sequence = 0)
[2019-11-12 20:15:19.547683511 UTC]  INFO | ThreadId 11    | showctx/proposer                    | 690d3131bb8fce05f6fb79dffaaa4be687c766a0
[2019-11-12 20:15:19.547832008 UTC]  INFO | ThreadId 11    | showctx/validators                  | ["690d3131bb8fce05f6fb79dffaaa4be687c766a0"]
[2019-11-12 20:15:19.547981406 UTC]  INFO | ThreadId 11    | showctx/mBlockNumber                | Nothing
[2019-11-12 20:15:19.548097831 UTC]  INFO | ThreadId 11    | showctx/mLockedBlockNo              | Nothing
[2019-11-12 20:15:19.548210995 UTC]  INFO | ThreadId 11    | showctx/mLockedSender               | Nothing
[2019-11-12 20:15:19.562791228 UTC]  INFO | ThreadId 11    | checkForUnseq                       | Applied pending LDB writes
[2019-11-12 20:15:19.563090658 UTC]  INFO | ThreadId 11    | sequencer/events                    | Reading from fused channels...
+ proc_pid=44
+ MONITORED_PIDS[${proc_pid}]='strato-sequencer   --validators=["690d3131bb8fce05f6fb79dffaaa4be687c766a0"] --blockstanbul=true     --minLogLevel=LevelInfo +RTS  -N1'
+ strato-sequencer '--validators=["690d3131bb8fce05f6fb79dffaaa4be687c766a0"]' --blockstanbul=true --minLogLevel=LevelInfo +RTS -N1
+ echo 'process pid:: 44 (command: strato-sequencer' '' '' '--validators=["690d3131bb8fce05f6fb79dffaaa4be687c766a0"]' --blockstanbul=true '' '' '' '' --minLogLevel=LevelInfo +RTS '' '-N1)'
process pid:: 44 (command: strato-sequencer   --validators=["690d3131bb8fce05f6fb79dffaaa4be687c766a0"] --blockstanbul=true     --minLogLevel=LevelInfo +RTS  -N1)
+ disown %
blockapps-init for ThreadId 4
strato-sequencer ignoring unknown flags: []
strato-sequencer validators: "[\"690d3131bb8fce05f6fb79dffaaa4be687c766a0\"]"
strato-sequencer authorized beneficiary senders"[]"
Checkpoint: Checkpoint {checkpointView = View {_round = 8, _sequence = 0}, checkpointVoteRecord = fromList [], checkpointValidators = [690d3131bb8fce05f6fb79dffaaa4be687c766a0], checkpointAdmins = []}
Interpreted validators: [690d3131bb8fce05f6fb79dffaaa4be687c766a0]
NODEKEY address: 690d3131bb8fce05f6fb79dffaaa4be687c766a0
[2019-11-12 20:15:55.743100398 UTC]  INFO | ThreadId 10    | readUnseqEvents'                    | Fetching unseqevents from Offset 8
[2019-11-12 20:15:55.764162189 UTC]  INFO | ThreadId 12    | sequencer                           | Sequencer startup
[2019-11-12 20:15:55.764327844 UTC]  INFO | ThreadId 12    | sequencer                           | Sequencer initialized
[2019-11-12 20:15:55.764609264 UTC]  INFO | ThreadId 12    | sequencer/events                    | Reading from fused channels...
[2019-11-12 20:16:05.815114159 UTC]  INFO | ThreadId 12    | sequencer/events                    | read 1 events from fused channels
[2019-11-12 20:16:05.815384224 UTC]  INFO | ThreadId 12    | blockstanbul/InShortLog             | TIMEOUT 8
[2019-11-12 20:16:05.815486616 UTC]  INFO | ThreadId 12    | showctx/view                        | View (round = 8, sequence = 0)
[2019-11-12 20:16:05.815572478 UTC]  INFO | ThreadId 12    | showctx/proposer                    | 690d3131bb8fce05f6fb79dffaaa4be687c766a0
[2019-11-12 20:16:05.815667327 UTC]  INFO | ThreadId 12    | showctx/validators                  | ["690d3131bb8fce05f6fb79dffaaa4be687c766a0"]
[2019-11-12 20:16:05.815762621 UTC]  INFO | ThreadId 12    | showctx/mBlockNumber                | Nothing
[2019-11-12 20:16:05.815842093 UTC]  INFO | ThreadId 12    | showctx/mLockedBlockNo              | Nothing
[2019-11-12 20:16:05.815922377 UTC]  INFO | ThreadId 12    | showctx/mLockedSender               | Nothing```
