### PR TITLE
provide default genesis block data for all modes

### DIFF
--- a/strato
+++ b/strato
@@ -483,13 +483,13 @@ else
       echo "useSyncMode: $useSyncMode"
     fi
   fi
-  if [[ -e "genesis-block.json" && -z ${genesis+x} ]]
-  then
-    export genesisBlock=$(< genesis-block.json)
-  fi
 fi
 
 echo "" && echo "*** Genesis Block ***"
+if [[ -e "genesis-block.json" && -z ${genesis+x} ]]
+then
+  export genesisBlock=$(< genesis-block.json)
+fi
 if [ -z ${genesisBlock+x} ]
 then
   echo "Genesis block is not set (using default)"


### PR DESCRIPTION
There was a bug where we didn't provide the docker-compose.json content as the env var to strato when running with --single flag.