### PR TITLE
Return with exit code 0 if the password is already set

### DIFF
--- a/strato
+++ b/strato
@@ -196,7 +196,7 @@ function setPassword {
         ;;
       "\"Password is already set\"" )
         echo "Password is already set and node is active"
-        exit 16
+        exit 0
         ;;
     esac
 }


### PR DESCRIPTION
This will allow run scripts to continue running if trying to restart a node without clearing vault.
Another option: identify a way to catch code 16 in the run script and continue without breaking.